### PR TITLE
Use remote_syslog2 from papertrail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,0 @@
-source 'https://rubygems.org'
-gem 'remote_syslog'

--- a/README.md
+++ b/README.md
@@ -3,22 +3,25 @@ openshift-papertrailapp-cartridge
 
 ####This only works on non-scaled gears at the moment
 
-Add an environment variable for your papertrailapp port number:
+Add an environment variables for your papertrailapp port number and hostname:
 
+    rhc set-env PAPERTRAILAPP_HOST=<host>.papertrailapp.com -a <appname>
     rhc set-env PAPERTRAILAPP_PORT=<port> -a <appname>
 
-Where <port> is your papertrailapp port number, and <appname> is the name of your application.
-Then restart your application
+
+Where <host> is your host and <port> is your papertrailapp port
+number, and <appname> is the name of your application.  Then restart
+your application
 
     rhc app restart <appname>
-    
+
 Then install this cartridge
 
-    rhc cartridge-add https://raw.github.com/developercorey/openshift-papertrailapp-cartridge/master/metadata/manifest.yml -a <appname>
-    
+    rhc cartridge-add https://raw.github.com/openshift-cartridges/openshift-papertrailapp-cartridge/master/metadata/manifest.yml -a <appname>
+
 This cartridge will monitor the files in all log directories that are published as environment variables, and exist.
 You can ssh into your gear and run the following command to see what directories will be monitored
 
     env | grep LOG
-    
+
 Please log any issues to the git repository issue tracker

--- a/bin/control
+++ b/bin/control
@@ -16,52 +16,62 @@ function isrunning() {
 }
 
 function start() {
-	echo "Starting $cartridge_type cart"
-	export PATH=/opt/rh/ruby193/root/bin:$PATH
-	export LD_LIBRARY_PATH=/opt/rh/ruby193/root/usr/lib64
-	if [ ! $PAPERTRAILAPP_PORT ]; then
-		client_result "Missing PAPERTRAILAPP_PORT environment variable."
-		client_result "Please run the following commands:"
-		client_result "rhc set-env PAPERTRAILAPP_PORT=12345 -a $OPENSHIFT_APP_NAME"
-		client_result "rhc app restart $OPENSHIFT_APP_NAME"
-		client_result "Where 12345 is YOUR papertrailapp port"
-		echo "testing"
-		exit 0
-	else
-		if [ -f $OPENSHIFT_PAPERTRAILAPP_DIR/log_files.yml ]; then
-			rm -f $OPENSHIFT_PAPERTRAILAPP_DIR/log_files.yml
-		fi
-		echo "files:" >> $OPENSHIFT_PAPERTRAILAPP_DIR/log_files.yml
-		LOG_DIRS=(`env | grep LOG`)
-		for i in "${LOG_DIRS[@]}"
-		do
-			IFS='=' read -a array <<< "$i"
-			if [ -d "${array[1]}" ];then
-			        echo "  - ${array[1]}*" >> $OPENSHIFT_PAPERTRAILAPP_DIR/log_files.yml
-			else
-			        echo "no dir ${array[1]}"
-			fi
-		done
-		echo "destination:" >> $OPENSHIFT_PAPERTRAILAPP_DIR/log_files.yml
-		echo "  host: 67.214.212.105 " >> $OPENSHIFT_PAPERTRAILAPP_DIR/log_files.yml
-		echo "  port: $PAPERTRAILAPP_PORT" >> $OPENSHIFT_PAPERTRAILAPP_DIR/log_files.yml
-		cd $OPENSHIFT_PAPERTRAILAPP_DIR 
-		bundle exec remote_syslog -c $OPENSHIFT_PAPERTRAILAPP_DIR/log_files.yml --hostname ${OPENSHIFT_APP_DNS} -D --tcp --tls >> $OPENSHIFT_PAPERTRAILAPP_DIR/logs/papertrailapp.log 2>&1 &
-	fi
-	exit 0
-	
+        echo "Starting $cartridge_type cart"
+        export PATH=/opt/rh/ruby193/root/bin:$PATH
+        export LD_LIBRARY_PATH=/opt/rh/ruby193/root/usr/lib64
+        if [ ! $PAPERTRAILAPP_PORT ]; then
+                client_result "Missing PAPERTRAILAPP_PORT environment variable."
+                client_result "Please run the following commands:"
+                client_result "rhc set-env PAPERTRAILAPP_PORT=12345 -a $OPENSHIFT_APP_NAME"
+                client_result "rhc app restart $OPENSHIFT_APP_NAME"
+                client_result "Where 12345 is YOUR papertrailapp port"
+                echo "testing"
+                exit 0
+        elif [ ! $PAPERTRAILAPP_HOST ]; then
+                client_result "Missing PAPERTRAILAPP_HOST environment variable."
+                client_result "Please run the following commands:"
+                client_result "rhc set-env PAPERTRAILAPP_HOST=<host>.papertrailapp.com -a $OPENSHIFT_APP_NAME"
+                client_result "rhc app restart $OPENSHIFT_APP_NAME"
+                client_result "Where <host> is YOUR papertrailapp host"
+                echo "testing"
+                exit 0
+        else
+                if [ -f $OPENSHIFT_PAPERTRAILAPP_DIR/log_files.yml ]; then
+                        rm -f $OPENSHIFT_PAPERTRAILAPP_DIR/log_files.yml
+                fi
+                echo "files:" >> $OPENSHIFT_PAPERTRAILAPP_DIR/log_files.yml
+                LOG_DIRS=(`env | grep LOG_DIR`)
+                for i in "${LOG_DIRS[@]}"
+                do
+                        IFS='=' read -a array <<< "$i"
+                        if [ -d "${array[1]}" ];then
+                                echo "  - ${array[1]}*" >> $OPENSHIFT_PAPERTRAILAPP_DIR/log_files.yml
+                        else
+                                echo "no dir ${array[1]}"
+                        fi
+                done
+                echo "hostname: ${OPENSHIFT_APP_NAME}" >> $OPENSHIFT_PAPERTRAILAPP_DIR/log_files.yml
+                echo "destination:" >> $OPENSHIFT_PAPERTRAILAPP_DIR/log_files.yml
+                echo "  host: $PAPERTRAILAPP_HOST" >> $OPENSHIFT_PAPERTRAILAPP_DIR/log_files.yml
+                echo "  port: $PAPERTRAILAPP_PORT" >> $OPENSHIFT_PAPERTRAILAPP_DIR/log_files.yml
+                echo "  protocol: tls" >> $OPENSHIFT_PAPERTRAILAPP_DIR/log_files.yml
+                cd $OPENSHIFT_PAPERTRAILAPP_DIR
+                ./remote_syslog -c $OPENSHIFT_PAPERTRAILAPP_DIR/log_files.yml --pid-file=$OPENSHIFT_PAPERTRAILAPP_DIR/remote_syslog.pid >> $OPENSHIFT_PAPERTRAILAPP_DIR/logs/papertrailapp.log 2>&1
+        fi
+        exit 0
+
 }
 
 
 function stop() {
-	echo "Stopping $cartridge_type cart"
-	if isrunning
-	then
-		pid=$(ps -ef | grep "[r]emote_syslog" | awk '{print $2}')
-		echo "Sending SIGTERM to papertrailapp:$pid ..." 1>&2
-		kill $pid
-	fi
-  
+        echo "Stopping $cartridge_type cart"
+        if isrunning
+        then
+                pid=$(ps -ef | grep "[r]emote_syslog" | awk '{print $2}')
+                echo "Sending SIGTERM to papertrailapp:$pid ..." 1>&2
+                kill $pid
+        fi
+
 }
 
 function restart() {

--- a/bin/setup
+++ b/bin/setup
@@ -1,6 +1,4 @@
 #!/bin/bash -eu
 
-export PATH=/opt/rh/ruby193/root/bin:$PATH
-export LD_LIBRARY_PATH=/opt/rh/ruby193/root/usr/lib64
 mkdir $OPENSHIFT_PAPERTRAILAPP_DIR/logs
-cd $OPENSHIFT_PAPERTRAILAPP_DIR && bundle install
+cd $OPENSHIFT_PAPERTRAILAPP_DIR  && curl -sLO https://github.com$(curl -Ls https://github.com/papertrail/remote_syslog2/releases/latest | egrep -o '/papertrail/remote_syslog2/releases/download/v[0-9]+\.[0-9]*/remote_syslog_linux_amd64.tar.gz') && tar -xzf ./remote_syslog_linux_amd64.tar.gz remote_syslog/remote_syslog --strip-components=1 && chmod +x ./remote_syslog

--- a/metadata/manifest.yml
+++ b/metadata/manifest.yml
@@ -8,7 +8,7 @@ License-Url: http://www.gnu.org/copyleft/lesser.txt
 Vendor: papertrail
 Cartridge-Version: 0.0.1
 Cartridge-Vendor: papertrailapp
-Source-Url: https://github.com/developercorey/openshift-papertrailapp-cartridge.git
+Source-Url: https://github.com/openshift-cartridges/openshift-papertrailapp-cartridge.git
 Categories:
 - service
 - embedded


### PR DESCRIPTION
Removes the ruby version of remote_syslog and uses the latest
remote_syslog2 from https://github.com/papertrail/remote_syslog2

Updates the readme for correct setup.